### PR TITLE
Update zig-a-zig-ah.md

### DIFF
--- a/docs/projects/zig-a-zig-ah.md
+++ b/docs/projects/zig-a-zig-ah.md
@@ -314,6 +314,10 @@ A checklist to go through if you get this error message:
   * Are you using any virtualisation/container pass-through for the USB device? There have been reports of these potentially causing problems so for debugging purposes try communicating with the adapter directly from the host OS it is connected to (i.e: see if it works without the bypass)
   * Make sure you are using an up-to-date version of Zigbee2mqtt on the host and firmware on the adapter.
 
+** "Error: Coordinator failed to start, probably the panID is already in use, try a different panID or channel" **
+
+This error can appear when migrating an existing installation of zigbee2mqtt to use zzh. Changing the Zigbee channel used or Personal Area Network Identifier (PAN ID) should be sfficient to prevent conflicts with previous configurations. This can be accomplished by editing [`configuration.yaml`](https://www.zigbee2mqtt.io/information/configuration.html), specifying a custom `channel` or `pan_id` under the `advanced` section. Valid channels are in the range 11 to 26, however channels in the Zigbee Light Link (ZLL) range are recommended; channel 11 (default), 15, 20, or 25. PAN ID can by any 16-bit value (default: `0x1a62`). Note that these changes will require re-pairing of existing devices.
+
 ### Zigbee Home Automation (ZHA) integration in Home Assistant
 
 [Zigbee Home Automation (ZHA)](https://www.home-assistant.io/integrations/zha/) integration is a built-in component in Home Assistant for native support, this makes the initial configuration very simple as you connect to the zzh adapter directly from Home Assistant's UI.


### PR DESCRIPTION
Updated troubleshooting section to include section on panID/channel conflicts with existing zigbee2mqtt installations.

This is mentioned (briefly) in the [zigbee2mqtt documentation](https://www.zigbee2mqtt.io/information/supported_adapters.html#electrolama-zig-a-zig-ah-zzh) but is likely helpful here too.