### PR TITLE
Update zigbee2mqtt.md to match firmware renaming

### DIFF
--- a/docs/radio-docs/zigbee2mqtt.md
+++ b/docs/radio-docs/zigbee2mqtt.md
@@ -1,6 +1,6 @@
 # Zigbee2mqtt
 
-Zigbee2mqtt has support for CC2652R chip used on this board. Download the Z-Stack coordinator firmware from [@Koenkk's firmware repository](https://github.com/Koenkk/Z-Stack-firmware). The firmware you'll need can be found under `coordinator/Z-Stack_3.x.0/bin/CC26X2R1_<date>.zip`, as of writing the latest version available is `CC26X2R1_20200805.zip`. Download and extract this and follow the ["Flashing using BSL"](#flashing-using-bsl) instructions to burn this on your zzh.
+Zigbee2mqtt has support for CC2652R chip used on this board. Download the Z-Stack coordinator firmware from [@Koenkk's firmware repository](https://github.com/Koenkk/Z-Stack-firmware). The firmware you'll need can be found under `coordinator/Z-Stack_3.x.0/bin/CC2652R_coordinator_<date>.zip`, as of writing the latest version available is `CC2652R_coordinator_20210120.zip`. Download and extract this and follow the ["Flashing using BSL"](#flashing-using-bsl) instructions to burn this on your zzh.
 
 ## Configuration
 


### PR DESCRIPTION
Updating firmware filename to match following renaming and restructuring in `Koenkk/Z-Stack-firmware`.

`CC26X2R1_20210120.zip` was changed to `CC2652R_20210120.zip` in [commit 49ade7c](https://github.com/Koenkk/Z-Stack-firmware/commit/49ade7c438cec32a88b1f5962ba246cc3e8fb454#diff-0fe9f3a846d5b003e3a111f78a5878117bf9034b0bb68fb13ef646dd8fbb880a), which then was renamed to `CC2652R_coordinator_20210120.hex.zip` in [42df803](https://github.com/Koenkk/Z-Stack-firmware/commit/42df8039b010bc859cafa236a70abf3e54b84e5c#diff-0fe9f3a846d5b003e3a111f78a5878117bf9034b0bb68fb13ef646dd8fbb880a) before ending at `CC2652R_coordinator_20210120.zip` in [commit 016b04e](https://github.com/Koenkk/Z-Stack-firmware/commit/016b04ecfda61a240d9be86726500d2dfc7fb1d2#diff-0fe9f3a846d5b003e3a111f78a5878117bf9034b0bb68fb13ef646dd8fbb880a)

